### PR TITLE
[Feat] S3 기반 파일 스토리지 구성 및 프로필 설정 기능 구현

### DIFF
--- a/src/main/java/com/somshare/somshare/config/AwsS3Config.java
+++ b/src/main/java/com/somshare/somshare/config/AwsS3Config.java
@@ -3,12 +3,11 @@ package com.somshare.somshare.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
-
-import org.springframework.context.annotation.Profile;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 /**
@@ -20,18 +19,21 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 @Profile({"dev", "prod"})
 public class AwsS3Config {
 
-    @Value("${aws.s3.access-key:}")
+    @Value("${aws.s3.access-key}")
     private String accessKey;
 
-    @Value("${aws.s3.secret-key:}")
+    @Value("${aws.s3.secret-key}")
     private String secretKey;
 
-    @Value("${aws.region:ap-northeast-2}")
+    @Value("${aws.region}")
     private String region;
 
-    @Value("${aws.s3.bucket:}")
+    @Value("${aws.s3.bucket}")
     private String bucketName;
 
+    /**
+     * S3 클라이언트 생성
+     */
     @Bean
     public S3Client s3Client() {
         AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
@@ -42,6 +44,9 @@ public class AwsS3Config {
                 .build();
     }
 
+    /**
+     * Presigned URL 발급용 Presigner
+     */
     @Bean
     public S3Presigner s3Presigner() {
         AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);

--- a/src/main/java/com/somshare/somshare/controller/FileController.java
+++ b/src/main/java/com/somshare/somshare/controller/FileController.java
@@ -3,8 +3,8 @@ package com.somshare.somshare.controller;
 import com.somshare.somshare.dto.PresignedUrlRequest;
 import com.somshare.somshare.dto.PresignedUrlResponse;
 import com.somshare.somshare.dto.UploadResponse;
-import com.somshare.somshare.service.FileStorageService;
 import com.somshare.somshare.service.PresignedUrlService;
+import com.somshare.somshare.service.S3FileStorageService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -15,12 +15,12 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/api/files")
 public class FileController {
 
-    private final FileStorageService storageService;
+    private final S3FileStorageService storageService;
 
     @Autowired(required = false)
     private PresignedUrlService presignedUrlService;
 
-    public FileController(FileStorageService storageService) {
+    public FileController(S3FileStorageService storageService) {
         this.storageService = storageService;
     }
 
@@ -31,19 +31,17 @@ public class FileController {
                 stored.originalName(),
                 stored.storedName(),
                 stored.url(),
-                stored.size(),
-                stored.contentType(),
-                stored.createdAt()
+                stored.size()
         ));
     }
+
 
     @PostMapping("/presigned-url")
     public ResponseEntity<PresignedUrlResponse> generatePresignedUrl(
             @Valid @RequestBody PresignedUrlRequest request
     ) {
         if (presignedUrlService == null) {
-            return ResponseEntity.status(501)
-                    .body(null); // simple/local 프로파일에서는 지원하지 않음
+            return ResponseEntity.status(501).body(null); // simple/local 프로파일에서는 지원하지 않음
         }
 
         PresignedUrlResponse response = presignedUrlService.generatePresignedUrl(request);

--- a/src/main/java/com/somshare/somshare/dto/UploadResponse.java
+++ b/src/main/java/com/somshare/somshare/dto/UploadResponse.java
@@ -6,7 +6,5 @@ public record UploadResponse(
         String originalName,
         String storedName,
         String url,
-        long size,
-        String contentType,
-        LocalDateTime createdAt
+        long size
 ) {}

--- a/src/main/java/com/somshare/somshare/service/AuthService.java
+++ b/src/main/java/com/somshare/somshare/service/AuthService.java
@@ -35,7 +35,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final EmailVerificationRepository verificationRepository;
     private final BCryptPasswordEncoder passwordEncoder;
-    private final FileStorageService fileStorageService;
+    private final S3FileStorageService fileStorageService;
 
     @Value("${jwt.secret:somshare-secret-key-for-jwt-token-generation-minimum-256-bits}")
     private String jwtSecretKey;
@@ -102,7 +102,7 @@ public class AuthService {
         // 프로필 이미지 업로드 (있는 경우)
         String profileImageUrl = null;
         if (request.getProfileImage() != null && !request.getProfileImage().isEmpty()) {
-            FileStorageService.StoredFile storedFile = fileStorageService.storeImage(request.getProfileImage());
+            S3FileStorageService.StoredFile storedFile = fileStorageService.storeImage(request.getProfileImage());
             profileImageUrl = storedFile.url();
         }
 

--- a/src/main/java/com/somshare/somshare/service/S3FileStorageService.java
+++ b/src/main/java/com/somshare/somshare/service/S3FileStorageService.java
@@ -1,0 +1,92 @@
+package com.somshare.somshare.service;
+
+import com.somshare.somshare.config.AwsS3Config;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3FileStorageService {
+
+    private final S3Client s3Client;
+    private final AwsS3Config awsS3Config;
+
+    private static final Set<String> ALLOWED_PDF_MIME = Set.of("application/pdf");
+    private static final Set<String> ALLOWED_IMAGE_MIME = Set.of(
+            "image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp"
+    );
+
+    public StoredFile storePdf(MultipartFile file) throws IOException {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("파일이 비어있습니다.");
+        }
+
+        String contentType = file.getContentType();
+        String originalName = StringUtils.cleanPath(file.getOriginalFilename() == null ? "" : file.getOriginalFilename());
+
+        boolean mimeOk = contentType != null && ALLOWED_PDF_MIME.contains(contentType);
+        boolean extOk = originalName.toLowerCase().endsWith(".pdf");
+
+        if (!mimeOk && !extOk) {
+            throw new IllegalArgumentException("PDF 파일만 업로드할 수 있습니다.");
+        }
+
+        return uploadToS3(file, "pdfs/", contentType);
+    }
+
+    public StoredFile storeImage(MultipartFile file) throws IOException {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("파일이 비어있습니다.");
+        }
+
+        String contentType = file.getContentType();
+        String originalName = StringUtils.cleanPath(file.getOriginalFilename() == null ? "" : file.getOriginalFilename());
+
+        boolean mimeOk = contentType != null && ALLOWED_IMAGE_MIME.contains(contentType);
+        boolean extOk = originalName.toLowerCase().matches(".*\\.(jpg|jpeg|png|gif|webp)$");
+
+        if (!mimeOk && !extOk) {
+            throw new IllegalArgumentException("이미지 파일만 업로드할 수 있습니다. (jpg, jpeg, png, gif, webp)");
+        }
+
+        // 파일 크기 제한 (5MB)
+        if (file.getSize() > 5 * 1024 * 1024) {
+            throw new IllegalArgumentException("이미지 크기는 5MB 이하여야 합니다.");
+        }
+
+        return uploadToS3(file, "profiles/", contentType);
+    }
+
+    private StoredFile uploadToS3(MultipartFile file, String folder, String contentType) throws IOException {
+        String originalName = StringUtils.cleanPath(file.getOriginalFilename() == null ? "" : file.getOriginalFilename());
+        String safeOriginal = originalName.replaceAll("[\\\\/:*?\"<>|]", "_");
+        String storedName = folder + UUID.randomUUID() + "-" + safeOriginal;
+
+        String bucketName = awsS3Config.getBucketName();
+
+        // S3에 업로드
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(storedName)
+                .contentType(contentType)
+                .build();
+
+        s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+        // S3 URL 생성
+        String url = String.format("https://%s.s3.ap-northeast-2.amazonaws.com/%s", bucketName, storedName);
+
+        return new StoredFile(originalName, storedName, url, file.getSize());
+    }
+
+    public record StoredFile(String originalName, String storedName, String url, long size) {}
+}


### PR DESCRIPTION
## 📌 관련 이슈

- Closes #10 
- Closes #18 

## 🏷️ PR 타입

- [x] ✨ 기능 추가 (feat)
- [ ] 🐛 버그 수정 (fix)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 📝 문서 수정 (docs)
- [ ] 🔧 설정 변경 (chore)

## 📝 작업 내용

- AWS S3 버킷 생성 및 PDF/이미지 저장용 스토리지 구성
- S3 Public Access 차단 및 IAM 최소 권한 정책 설정
- S3 CORS 설정을 통한 프론트엔드 업로드 환경 구성
- 환경변수 기반 S3 설정 (bucket, region 등) 분리
- 프로필 이미지 S3 업로드 로직 구현
- 프로필 설정 API (닉네임, 대학, 전공, 프로필 이미지) 구현
- 회원가입 → 프로필 설정 → 메인 페이지 사용자 플로우 연결
- 추후 Presigned URL 방식 확장을 고려한 구조로 설계

## 📸 스크린샷

<img width="939" height="557" alt="스크린샷 2026-01-05 173901" src="https://github.com/user-attachments/assets/2be644b1-ed4f-4627-8831-13afb4c4f6c8" />


## ✅ 체크리스트

- [x] 코드 리뷰를 받을 준비가 완료되었습니다
- [x] 로컬 환경에서 기능 테스트를 완료했습니다
- [x] 셀프 리뷰를 완료했습니다

## 📎 기타 참고사항

- 현재는 서버에서 직접 S3 업로드하는 방식이며,
  추후 Presigned URL 방식으로 개선 예정입니다.
- S3 경로 및 파일명 규칙은 사용자 단위로 관리되도록 설계했습니다.
