### PR TITLE
게시글 삭제 시 S3 파일 동시 삭제 기능 추가

### DIFF
--- a/src/main/java/com/somshare/somshare/service/ExamPostServiceImpl.java
+++ b/src/main/java/com/somshare/somshare/service/ExamPostServiceImpl.java
@@ -23,6 +23,7 @@ public class ExamPostServiceImpl implements ExamPostService {
     private final ExamPostRepository examPostRepository;
     private final DepartmentRepository departmentRepository;
     private final UserRepository userRepository;
+    private final S3FileStorageService s3FileStorageService;
 
     @Override
     public List<ExamPostResponse> getExamPostsByDepartment(Long departmentId) {
@@ -107,6 +108,12 @@ public class ExamPostServiceImpl implements ExamPostService {
         // 작성자만 삭제
         if (!post.getUploader().getId().equals(requester.getId())) {
             throw new SecurityException("삭제 권한이 없습니다.");
+        }
+
+        // S3에서 파일 삭제
+        String fileKey = post.getFileKey();
+        if (fileKey != null && !fileKey.isBlank()) {
+            s3FileStorageService.deleteFile(fileKey);
         }
 
         examPostRepository.delete(post);

--- a/src/main/java/com/somshare/somshare/service/S3FileStorageService.java
+++ b/src/main/java/com/somshare/somshare/service/S3FileStorageService.java
@@ -154,6 +154,38 @@ public class S3FileStorageService {
         }
     }
 
+    /**
+     * S3에서 파일 삭제
+     * @param fileKey S3 객체 키 (예: pdfs/uuid-filename.pdf)
+     */
+    public void deleteFile(String fileKey) {
+        if (fileKey == null || fileKey.isBlank()) {
+            log.warn("[S3_DELETE_SKIP] reason=empty_key");
+            return;
+        }
+
+        long start = System.currentTimeMillis();
+        String bucketName = awsS3Config.getBucketName();
+
+        log.info("[S3_DELETE_START] bucket={} key={}", bucketName, safeName(fileKey));
+
+        try {
+            software.amazon.awssdk.services.s3.model.DeleteObjectRequest deleteRequest =
+                    software.amazon.awssdk.services.s3.model.DeleteObjectRequest.builder()
+                            .bucket(bucketName)
+                            .key(fileKey)
+                            .build();
+
+            s3Client.deleteObject(deleteRequest);
+
+            log.info("[S3_DELETE_OK] key={} elapsedMs={}", safeName(fileKey), System.currentTimeMillis() - start);
+
+        } catch (Exception e) {
+            log.error("[S3_DELETE_FAIL] key={} elapsedMs={}", safeName(fileKey), System.currentTimeMillis() - start, e);
+            // 삭제 실패해도 DB 삭제는 진행되도록 예외를 던지지 않음
+        }
+    }
+
     private String safeName(String name) {
         if (name == null) return "null";
         // 로그 깨는 문자 제거


### PR DESCRIPTION
  📌 관련 이슈

  - #9

  ---
  🏷️ PR 타입

  - [x] ✨ 기능 추가 (feat)
  - [ ] 🐛 버그 수정 (fix)
  - [ ] ♻️ 리팩토링 (refactor)
  - [ ] 📝 문서 수정 (docs)
  - [ ] 🔧 설정 변경 (chore)

  ---
  📝 작업 내용

  1. 게시글 삭제 시 S3 파일 동시 삭제 기능 추가 

  DELETE /departments/{departmentId}/exam-posts/{postId}
  - 게시글 삭제 시 S3에 저장된 PDF 파일도 함께 삭제
  - fileKey를 사용하여 S3 객체 삭제
  - S3 삭제 실패해도 DB 삭제는 정상 진행 (데이터 정합성 우선)

  2. 수정된 파일

  S3FileStorageService.java
  - deleteFile(String fileKey) 메서드 추가
  - S3 DeleteObjectRequest를 통한 파일 삭제
  - 삭제 시작/성공/실패 로그 기록

  ExamPostServiceImpl.java
  - S3FileStorageService 의존성 주입 추가
  - deleteExamPost() 메서드에서 S3 파일 삭제 로직 추가

  3. 삭제 흐름

  1. 사용자 인증 확인
  2. 게시글 존재 확인
  3. 작성자 권한 확인
  4. S3에서 PDF 파일 삭제 (fileKey 사용)
  5. DB에서 게시글 삭제

  4. 주요 기능

  S3 파일 삭제:
  - [x] fileKey가 null 또는 빈 값일 경우 삭제 건너뜀
  - [x] S3 삭제 실패 시에도 DB 삭제 진행 (예외 미전파)
  - [ ] 삭제 작업 로깅 ([S3_DELETE_START], [S3_DELETE_OK], [S3_DELETE_FAIL])

  예외 처리:
  - [x] S3 삭제 실패 시 로그만 기록, 예외 미전파
  - [x] 기존 권한 체크 로직 유지 (작성자 본인만 삭제 가능)

  ---
  📸 스크린샷

  (해당 없음 - 백엔드 로직 변경)

  ---
  ✅ 체크리스트

  - [x] 코드 리뷰를 받을 준비가 완료되었습니다
  - [ ] 테스트를 작성하고 모두 통과했습니다
  - [x] 셀프 리뷰를 완료했습니다

  ---
  📎 기타 참고사항

  - 인프라 구조상 Spring Boot API가 S3 PDF Bucket에 접근하여 파일 삭제
  - Presigned URL 방식으로 업로드된 파일도 fileKey로 삭제 가능

  ---